### PR TITLE
Dictionaryapi is optional.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,16 @@ database are going to be consumed in sync way (O(n)). In async mode all words in
 are going to be split in two lists and consumed in parallel in two threads.    
 Default is async mode.
 
-To change modes run jar with variable: **-Dkorvo-to-anki=sync**
+To change modes run jar with variable: **-Dkorvo-to-anki.async=true**
+
+#### Available options of jar startup
+
+    * korvo-to-anki.api.dictionaryApiEnabled: true/false - turn of or off dictionaryapi service
+    * korvo-to-anki.async: true/false - turn on or off async run
 
 #### On linux
 
-`java -jar -Dkorvo-to-anki.async=true -Dspring.datasource.url=jdbc:sqlite:/path/to/vocabulary_builder.sqlite3 korvo-to-anki.jar `
+`java -jar Dkorvo-to-anki.async=false -Dkorvo-to-anki.api.dictionaryApiEnabled=false -Dspring.datasource.url=jdbc:sqlite:/path/to/vocabulary_builder.sqlite3 korvo-to-anki.jar `
 
 #### On windows
 
@@ -102,7 +107,6 @@ dictionaryapi. To show them in card one has to change card template.
 {{hint:Meaning}}
 ```
 
-
 #### Example result
 
 ```text
@@ -127,6 +131,8 @@ service [dictionaryapi.dev](https://dictionaryapi.dev/). The current limit is 45
 minutes. When reached app fall asleep for 5 minutes and then retry to get word definition of last
 word and run further as normal until requests limit is reached again.    
 With all limitations export of 3080 words with sleep timeout was done in about _**30 minutes**_
+
+Dictionary api works only with english source language. Any other languages won't work same as auto.
 
 ### Example
 

--- a/src/main/java/ru/dankoy/korvotoanki/config/Languages.java
+++ b/src/main/java/ru/dankoy/korvotoanki/config/Languages.java
@@ -1,0 +1,5 @@
+package ru.dankoy.korvotoanki.config;
+
+public enum Languages {
+  EN, RU, AUTO
+}

--- a/src/main/java/ru/dankoy/korvotoanki/config/TemplateBuilderConfig.java
+++ b/src/main/java/ru/dankoy/korvotoanki/config/TemplateBuilderConfig.java
@@ -11,7 +11,8 @@ public class TemplateBuilderConfig {
 
 
   @Bean
-  TemplateBuilder templateBuilder(@Value("${spring.freemarker.template-loader-path}") String templatesDir) {
+  TemplateBuilder templateBuilder(
+      @Value("${spring.freemarker.template-loader-path}") String templatesDir) {
     return new TemplateBuilderImpl(templatesDir);
   }
 

--- a/src/main/java/ru/dankoy/korvotoanki/config/appprops/AppProperties.java
+++ b/src/main/java/ru/dankoy/korvotoanki/config/appprops/AppProperties.java
@@ -11,7 +11,8 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @Getter
 @RequiredArgsConstructor
 @ConfigurationProperties(prefix = "korvo-to-anki")
-public class AppProperties implements GoogleTranslatorProperties, DebugProperties, DictionaryApiProperties {
+public class AppProperties implements GoogleTranslatorProperties, DebugProperties,
+    DictionaryApiProperties {
 
   private final String googleTranslatorUrl;
 

--- a/src/main/java/ru/dankoy/korvotoanki/config/appprops/AppPropertiesConfig.java
+++ b/src/main/java/ru/dankoy/korvotoanki/config/appprops/AppPropertiesConfig.java
@@ -5,7 +5,8 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@EnableConfigurationProperties({AppProperties.class, GoogleParamsProperties.class})
+@EnableConfigurationProperties({AppProperties.class, GoogleParamsProperties.class,
+    ExternalApiParams.class})
 public class AppPropertiesConfig {
 
 }

--- a/src/main/java/ru/dankoy/korvotoanki/config/appprops/ExternalApiParams.java
+++ b/src/main/java/ru/dankoy/korvotoanki/config/appprops/ExternalApiParams.java
@@ -1,0 +1,16 @@
+package ru.dankoy.korvotoanki.config.appprops;
+
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+
+@Getter
+@RequiredArgsConstructor
+@ConfigurationProperties(prefix = "korvo-to-anki.api")
+public class ExternalApiParams implements ExternalApiProperties {
+
+  private final boolean dictionaryApiEnabled;
+
+}

--- a/src/main/java/ru/dankoy/korvotoanki/config/appprops/ExternalApiProperties.java
+++ b/src/main/java/ru/dankoy/korvotoanki/config/appprops/ExternalApiProperties.java
@@ -1,0 +1,8 @@
+package ru.dankoy.korvotoanki.config.appprops;
+
+
+public interface ExternalApiProperties {
+
+  boolean isDictionaryApiEnabled();
+
+}

--- a/src/main/java/ru/dankoy/korvotoanki/core/command/AnkiConverterCommand.java
+++ b/src/main/java/ru/dankoy/korvotoanki/core/command/AnkiConverterCommand.java
@@ -5,6 +5,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.shell.command.annotation.Command;
 import org.springframework.shell.command.annotation.Option;
+import ru.dankoy.korvotoanki.core.domain.Title;
 import ru.dankoy.korvotoanki.core.domain.Vocabulary;
 import ru.dankoy.korvotoanki.core.service.converter.AnkiConverterService;
 import ru.dankoy.korvotoanki.core.service.objectmapper.ObjectMapperService;
@@ -23,13 +24,13 @@ public class AnkiConverterCommand {
       description = "Translate and define text using google translator and dictionaryapi.dev")
   public String translateAndConvert(
       @Option(required = true, description = "text to translate") String text,
-      @Option(required = false, defaultValue = "auto", description = "source language") String sourceLanguage,
+      @Option(required = false, defaultValue = "en", description = "source language") String sourceLanguage,
       @Option(required = false, defaultValue = "ru", description = "target language") String targetLanguage,
       @Option(required = false, defaultValue = "t,at,md,rm", description = "options") String[] options
   ) {
 
     var vocabulary = new Vocabulary(text,
-        null,
+        new Title(0, null, 0L),
         0L,
         0L,
         0L,
@@ -39,7 +40,8 @@ public class AnkiConverterCommand {
         0L);
 
     List<String> optionsList = Arrays.asList(options);
-    var ankiData = ankiConverterService.convert(vocabulary, sourceLanguage, targetLanguage, optionsList);
+    var ankiData = ankiConverterService.convert(vocabulary, sourceLanguage, targetLanguage,
+        optionsList);
 
     return objectMapperService.convertToString(ankiData);
   }

--- a/src/main/java/ru/dankoy/korvotoanki/core/command/AnkiExporterCommand.java
+++ b/src/main/java/ru/dankoy/korvotoanki/core/command/AnkiExporterCommand.java
@@ -21,7 +21,7 @@ public class AnkiExporterCommand {
       alias = "ae",
       description = "Export to anki. Translate and define text using google translator and dictionaryapi.dev")
   public String export(
-      @Option(required = false, defaultValue = "auto", description = "source language") String sourceLanguage,
+      @Option(required = false, defaultValue = "en", description = "source language") String sourceLanguage,
       @Option(required = false, defaultValue = "ru", description = "target language") String targetLanguage,
       @Option(required = false, defaultValue = "t,at,md,rm", description = "options") String[] options
   ) {

--- a/src/main/java/ru/dankoy/korvotoanki/core/command/GoogleTranslateCommand.java
+++ b/src/main/java/ru/dankoy/korvotoanki/core/command/GoogleTranslateCommand.java
@@ -22,7 +22,7 @@ public class GoogleTranslateCommand {
       description = "Translate text using google translate")
   public String translate(
       @Option(required = true, description = "text to translate") String text,
-      @Option(required = false, defaultValue = "auto", description = "source language") String sourceLanguage,
+      @Option(required = false, defaultValue = "en", description = "source language") String sourceLanguage,
       @Option(required = false, defaultValue = "ru", description = "target language") String targetLanguage,
       @Option(required = false, defaultValue = "t,at,md,rm", description = "options") String[] options
   ) {

--- a/src/main/java/ru/dankoy/korvotoanki/core/domain/anki/Meaning.java
+++ b/src/main/java/ru/dankoy/korvotoanki/core/domain/anki/Meaning.java
@@ -3,7 +3,7 @@ package ru.dankoy.korvotoanki.core.domain.anki;
 import java.util.List;
 
 /**
- * @param type noun, verb
+ * @param type        noun, verb
  * @param definitions actual definitions
  * @param synonyms
  * @param antonyms

--- a/src/main/java/ru/dankoy/korvotoanki/core/fabric/anki/AnkiDataFabric.java
+++ b/src/main/java/ru/dankoy/korvotoanki/core/fabric/anki/AnkiDataFabric.java
@@ -8,6 +8,7 @@ import ru.dankoy.korvotoanki.core.domain.googletranslation.GoogleTranslation;
 
 public interface AnkiDataFabric {
 
-  AnkiData createAnkiData(Vocabulary vocabulary, GoogleTranslation googleTranslation, List<Word> word);
+  AnkiData createAnkiData(Vocabulary vocabulary, GoogleTranslation googleTranslation,
+      List<Word> word);
 
 }

--- a/src/main/java/ru/dankoy/korvotoanki/core/service/converter/AnkiConverterServiceImpl.java
+++ b/src/main/java/ru/dankoy/korvotoanki/core/service/converter/AnkiConverterServiceImpl.java
@@ -6,6 +6,8 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import ru.dankoy.korvotoanki.config.Languages;
+import ru.dankoy.korvotoanki.config.appprops.ExternalApiProperties;
 import ru.dankoy.korvotoanki.core.domain.Vocabulary;
 import ru.dankoy.korvotoanki.core.domain.anki.AnkiData;
 import ru.dankoy.korvotoanki.core.domain.dictionaryapi.Word;
@@ -24,25 +26,32 @@ public class AnkiConverterServiceImpl implements AnkiConverterService {
   private final DictionaryService dictionaryService;
   private final GoogleTranslator googleTranslator;
   private final AnkiDataFabric ankiDataFabric;
+  private final ExternalApiProperties externalApiProperties;
 
   public AnkiData convert(Vocabulary vocabulary, String sourceLanguage, String targetLanguage,
       List<String> options) {
 
     List<Word> daResult = Collections.singletonList(Word.emptyWord());
-    try {
-      daResult = dictionaryService.define(vocabulary.word());
-    } catch (TooManyRequestsException e) {
-      log.warn("Hit rate limiter - {}. Going to sleep for 5 minutes and retry", e.getMessage());
-      sleep(310000);
-      //todo: make advanced retry when too many requests
+
+    var isDictionaryApiEnabled = externalApiProperties.isDictionaryApiEnabled();
+
+    // ignore auto source language because won't know the defined language. Look up for Tika Language Detection
+    if (isDictionaryApiEnabled && sourceLanguage.equals(Languages.EN.name().toLowerCase())) {
+
       try {
         daResult = dictionaryService.define(vocabulary.word());
-      } catch (DictionaryApiException e2) {
-        log.warn(String.format("Couldn't get definition from dictionaryapi.dev - %s", e2));
+      } catch (TooManyRequestsException e) {
+        log.warn("Hit rate limiter - {}. Going to sleep for 5 minutes and retry", e.getMessage());
+        sleep(310000);
+        //todo: make advanced retry when too many requests
+        try {
+          daResult = dictionaryService.define(vocabulary.word());
+        } catch (DictionaryApiException e2) {
+          log.warn(String.format("Couldn't get definition from dictionaryapi.dev - %s", e2));
+        }
+      } catch (DictionaryApiException e) {
+        log.warn(String.format("Couldn't get definition from dictionaryapi.dev - %s", e));
       }
-    }
-    catch (DictionaryApiException e) {
-      log.warn(String.format("Couldn't get definition from dictionaryapi.dev - %s", e));
     }
 
     var gtResult = googleTranslator.translate(vocabulary.word(), targetLanguage, sourceLanguage,

--- a/src/main/java/ru/dankoy/korvotoanki/core/service/exporter/ExporterServiceAnki.java
+++ b/src/main/java/ru/dankoy/korvotoanki/core/service/exporter/ExporterServiceAnki.java
@@ -22,15 +22,11 @@ import ru.dankoy.korvotoanki.core.service.vocabulary.VocabularyService;
 public class ExporterServiceAnki implements ExporterService {
 
   private static final int STEP_SIZE = 10;
-  private int counter = 0;
-
   private final VocabularyService vocabularyService;
-
   private final AnkiConverterService ankiConverterService;
-
   private final TemplateCreatorService templateCreatorService;
-
   private final IOService ioService;
+  private int counter = 0;
 
   @Override
   public void export(String sourceLanguage, String targetLanguage, List<String> options) {

--- a/src/main/java/ru/dankoy/korvotoanki/core/service/googletrans/GoogleTranslator.java
+++ b/src/main/java/ru/dankoy/korvotoanki/core/service/googletrans/GoogleTranslator.java
@@ -4,11 +4,11 @@ import java.util.List;
 import ru.dankoy.korvotoanki.core.domain.googletranslation.GoogleTranslation;
 
 /*
-* Used info from:
-* - https://github.com/koreader/koreader/blob/34ba2fab301f43533ee6876d78809f685dd05614/frontend/ui/translator.lua#L4
-* - https://koreader.rocks/doc/modules/ui.translator.html
-* - https://github.com/ssut/py-googletrans/blob/master/googletrans/client.py
-* */
+ * Used info from:
+ * - https://github.com/koreader/koreader/blob/34ba2fab301f43533ee6876d78809f685dd05614/frontend/ui/translator.lua#L4
+ * - https://koreader.rocks/doc/modules/ui.translator.html
+ * - https://github.com/ssut/py-googletrans/blob/master/googletrans/client.py
+ * */
 
 public interface GoogleTranslator {
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -32,7 +32,7 @@ korvo-to-anki:
     otf: 1                                      # ?
     ssel: 0                                     # ?
     tsel: 0                                     # ?
-    dt:                                         # what we want in result
+    dt: # what we want in result
       - "t"                                     # translation of source text
       - "at"                                    # alternate translations
       - "md"                                    # definitions of source text

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,13 +18,15 @@ logging:
 
 korvo-to-anki:
   async: true
+  api:
+    dictionaryApiEnabled: true
   dictionary-api-url: "https://api.dictionaryapi.dev/api/v2/entries/en/"
   google-translator-url: "https://translate.googleapis.com/translate_a/single"
   trans-params:
     client: "gtx"                               # (using "t" raises 403 Forbidden)
     ie: "UTF-8"                                 # input encoding
     oe: "UTF-8"                                 # output encoding
-    sl: "auto"                                  # source language (we need to specify "auto" to detect language)
+    sl: "en"                                  # source language (we need to specify "auto" to detect language)
     tl: "ru"                                    # target language
     hl: ${korvo-to-anki.trans-params.sl}        # ?
     otf: 1                                      # ?

--- a/src/main/resources/templates/korvo-to-anki.ftl
+++ b/src/main/resources/templates/korvo-to-anki.ftl
@@ -3,7 +3,7 @@
 #deck column:1
 #tags column:6
 <#list ankiDataList as ankiData>
-korvo-to-anki::${ankiData.book}|${ankiData.word}|${ankiData.translations?join(", ")}|${ankiData.myExample!""}|${ankiData.meanings}|${ankiData.book?replace(" ","_")}
+  korvo-to-anki::${ankiData.book}|${ankiData.word}|${ankiData.translations?join(", ")}|${ankiData.myExample!""}|${ankiData.meanings}|${ankiData.book?replace(" ","_")}
 </#list>
 
 


### PR DESCRIPTION
# Description

On startup one can disable or enable dictionaryapi requests if it is not neseccary. Also dictionary api doesn't work with any language except english, that's why made checker of source language. If it is not en and dictionaryapy is not enabled requests to it are ignored. 

Fixes #25 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test export and converter with startup keys -Dkorvo-to-anki.api.dictionaryApiEnabled=false
- [x] Test export and converter with source language != en

**Test Configuration**:
* Firmware version: MacOS 13.6
* Hardware: Apple M1 Pro
* SDK: JDK-17.0.8.1-tem

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

