### PR TITLE
Updated dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ imported to anki
 ### Stack
 
 * Java 17
-* Spring boot 3.12
+* Spring boot 3.2.2
 * Spring shell
 * Spring boot jdbc
 * Caffeine cache

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
     id 'org.springframework.boot' version '3.1.3'
-    id 'io.spring.dependency-management' version '1.1.3'
+    id 'io.spring.dependency-management' version '1.1.4'
 }
 
 group = 'ru.dankoy'

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.1.3'
+    id 'org.springframework.boot' version '3.2.2'
     id 'io.spring.dependency-management' version '1.1.4'
 }
 
@@ -33,7 +33,10 @@ dependencies {
     implementation 'ch.qos.logback:logback-classic'
     implementation 'ch.qos.logback:logback-core'
 
-    implementation 'org.xerial:sqlite-jdbc'
+    // sqlite with default version from spring boot bom (3.42.1) doesn't work with spring boot 3.2.2
+    // sqlite version 3.42.1 works with spring boot 3.1.3
+    // Working sqlite version with spring boot 3.2.2 is 3.45.1.0
+    implementation 'org.xerial:sqlite-jdbc:3.45.1.0'
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation 'com.squareup.okhttp3:okhttp'
     implementation 'com.squareup.okhttp3:logging-interceptor'

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-jdbc'
     implementation 'org.springframework.shell:spring-shell-starter'
 
-    implementation 'ch.qos.logback:logback-classic:1.4.11'
+    implementation 'ch.qos.logback:logback-classic'
+    implementation 'ch.qos.logback:logback-core'
 
     implementation 'org.xerial:sqlite-jdbc'
     implementation 'com.fasterxml.jackson.core:jackson-databind'

--- a/src/test/java/ru/dankoy/korvotoanki/core/service/templatebuilder/TemplateBuilderImplTest.java
+++ b/src/test/java/ru/dankoy/korvotoanki/core/service/templatebuilder/TemplateBuilderImplTest.java
@@ -25,8 +25,8 @@ import ru.dankoy.korvotoanki.core.dto.AnkiDataDTO;
 import ru.dankoy.korvotoanki.core.exceptions.KorvoRootException;
 
 
-@SpringBootTest
-@Import(value = TemplateBuilderConfig.class)
+@SpringBootTest(classes = {TemplateBuilder.class, TemplateBuilderConfig.class})
+//@Import(value = TemplateBuilderConfig.class)
 @DisplayName("Test TemplateBuilderImpl ")
 class TemplateBuilderImplTest {
 
@@ -68,7 +68,7 @@ class TemplateBuilderImplTest {
 
     var path = Paths.get(
         getClass().getResource("/templates/correct/correct-meaning.ftl").toURI());
-    var correct = String.join("\n", Files.readAllLines(path));
+    var correct = String.join(System.lineSeparator(), Files.readAllLines(path));
 
     Map<String, Object> templateData = new HashMap<>();
     templateData.put("ankiData", ankiData);
@@ -93,7 +93,7 @@ class TemplateBuilderImplTest {
 
     var path = Paths.get(
         getClass().getResource("/templates/correct/correct-korvo-to-anki-correct.ftl").toURI());
-    var correct = String.join("\n", Files.readAllLines(path));
+    var correct = String.join(System.lineSeparator(), Files.readAllLines(path));
 
     Map<String, Object> templateData = new HashMap<>();
     templateData.put("ankiDataList", Collections.singletonList(ankiData));


### PR DESCRIPTION
# Description

Updated dependencies for:
1) Spring boot 3.1.3 -> 3.2.2
2) logback-classic uses default version from spring bom
3) Spring dependency management 1.1.3 -> 1.1.4
4) default sqlite from bom 3.42.1 ->  3.45.1.0 because default version is not working with spring boot 3.2.2

Fixed tests for template builder.

## Type of change

- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Insert title. Should insert correctly and return id
- [x] Anki export. Should correctly translate and export

**Test Configuration**:
* Firmware version: MacOS 14
* Hardware: Macbook M1 Pro
* SDK: jdk-17.0.2

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

