### PR TITLE
dictionary api rate limiter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 apply plugin: "io.spring.dependency-management"
 
 group = 'ru.dankoy'
-version = '0.2.4-SNAPSHOT'
+version = '0.3.0-SNAPSHOT'
 
 java {
     sourceCompatibility = '21'

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 apply plugin: "io.spring.dependency-management"
 
 group = 'ru.dankoy'
-version = '0.2.3-SNAPSHOT'
+version = '0.2.4-SNAPSHOT'
 
 java {
     sourceCompatibility = '21'
@@ -26,11 +26,13 @@ repositories {
 
 ext {
     springShellVersion = '3.3.1'
+    resilience4jBomVersion = '2.2.0'
 }
 
 dependencyManagement {
     imports {
         mavenBom "org.springframework.shell:spring-shell-dependencies:${springShellVersion}"
+        mavenBom "io.github.resilience4j:resilience4j-bom:${resilience4jBomVersion}"
     }
 }
 
@@ -68,6 +70,13 @@ dependencies {
 
     // spotless
     implementation 'com.diffplug.spotless:spotless-lib:2.45.0'
+
+    // resilence4j
+    implementation 'io.github.resilience4j:resilience4j-spring-boot3'
+ //   implementation 'io.github.resilience4j:resilience4j-ratelimiter'
+    //implementation 'io.github.resilience4j:resilience4j-reactor'
+    implementation 'org.springframework.boot:spring-boot-starter-aop' // necessary for annotations
+    //implementation 'org.springframework.boot:spring-boot-starter-actuator'
 }
 
 test {

--- a/src/main/java/ru/dankoy/korvotoanki/core/exceptions/TooManyRequestsException.java
+++ b/src/main/java/ru/dankoy/korvotoanki/core/exceptions/TooManyRequestsException.java
@@ -1,6 +1,6 @@
 package ru.dankoy.korvotoanki.core.exceptions;
 
-public class TooManyRequestsException extends RuntimeException {
+public class TooManyRequestsException extends DictionaryApiException {
 
   public TooManyRequestsException(String message) {
     super(message);

--- a/src/main/java/ru/dankoy/korvotoanki/core/service/dictionaryapi/DictionaryServiceOkHttp.java
+++ b/src/main/java/ru/dankoy/korvotoanki/core/service/dictionaryapi/DictionaryServiceOkHttp.java
@@ -2,6 +2,7 @@ package ru.dankoy.korvotoanki.core.service.dictionaryapi;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.resilience4j.ratelimiter.annotation.RateLimiter;
 import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
@@ -30,6 +31,7 @@ public class DictionaryServiceOkHttp implements DictionaryService {
 
   private final ObjectMapper mapper;
 
+  @RateLimiter(name = "dictionary-api")
   @Cacheable(cacheManager = "cacheManager", value = "dictionaryApi", key = "#word")
   @Override
   public List<Word> define(String word) {

--- a/src/main/java/ru/dankoy/korvotoanki/core/service/exporter/ExporterServiceAnki.java
+++ b/src/main/java/ru/dankoy/korvotoanki/core/service/exporter/ExporterServiceAnki.java
@@ -19,6 +19,11 @@ import ru.dankoy.korvotoanki.core.service.state.StateService;
 import ru.dankoy.korvotoanki.core.service.templatecreator.TemplateCreatorService;
 import ru.dankoy.korvotoanki.core.service.vocabulary.VocabularyService;
 
+/**
+ * @deprecated in favor of {@link ExporterServiceAnkiAsync}
+ */
+
+@Deprecated(since = "2024-08-05", forRemoval = true)
 @Slf4j
 @ConditionalOnProperty(prefix = "korvo-to-anki", value = "async", havingValue = "false")
 @Service

--- a/src/main/java/ru/dankoy/korvotoanki/core/service/exporter/ExporterServiceAnki.java
+++ b/src/main/java/ru/dankoy/korvotoanki/core/service/exporter/ExporterServiceAnki.java
@@ -22,7 +22,6 @@ import ru.dankoy.korvotoanki.core.service.vocabulary.VocabularyService;
 /**
  * @deprecated in favor of {@link ExporterServiceAnkiAsync}
  */
-
 @Deprecated(since = "2024-08-05", forRemoval = true)
 @Slf4j
 @ConditionalOnProperty(prefix = "korvo-to-anki", value = "async", havingValue = "false")

--- a/src/main/java/ru/dankoy/korvotoanki/core/service/exporter/ExporterServiceAnkiAsync.java
+++ b/src/main/java/ru/dankoy/korvotoanki/core/service/exporter/ExporterServiceAnkiAsync.java
@@ -121,10 +121,9 @@ public class ExporterServiceAnkiAsync implements ExporterService {
       List<String> options) {
     for (Vocabulary v : vocabularies) {
       var i = atomicInteger.getAndIncrement();
+      // sleep is not necessary anymore since rate limiter for dictionary api is implemented
       if (i != 0 && i % STEP_SIZE == 0) {
         log.info("processed - {}", i);
-        log.debug("Sleep {}", Thread.currentThread().getName());
-        sleep(10000);
       }
       var ankiData = ankiConverterService.convert(v, sourceLanguage, targetLanguage, options);
       log.info(
@@ -134,15 +133,5 @@ public class ExporterServiceAnkiAsync implements ExporterService {
       ankiDataList.add(ankiData);
     }
     latch.countDown();
-  }
-
-  private void sleep(long ms) {
-
-    try {
-      Thread.sleep(ms);
-    } catch (InterruptedException e) {
-      Thread.currentThread().interrupt();
-      throw new KorvoRootException("Interrupted while trying to get data", e);
-    }
   }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -62,3 +62,11 @@ korvo-to-anki:
 #      - "rw"        # "see also" list
 #      - "ss"        # synonyms of source text, if it's one word
 debug: false
+
+
+resilience4j.ratelimiter:
+  instances:
+    dictionary-api:
+      limitForPeriod: 1
+      limitRefreshPeriod: 1s
+      timeoutDuration: 10s

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -67,6 +67,6 @@ debug: false
 resilience4j.ratelimiter:
   instances:
     dictionary-api:
-      limitForPeriod: 1
-      limitRefreshPeriod: 1s
+      limitForPeriod: 15
+      limitRefreshPeriod: 10s
       timeoutDuration: 10s


### PR DESCRIPTION
# Description

Added ratelimiter for external calls to dictionary api service. 

Since it has limit for 450 calls in 5 minutes, I made limiter to make 15 requests in 10 seconds, which makes 450 requests in 5 minutes. 

Changed build version to 0.3.0

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Test full export of db. Should never get 429 error from dictionary api.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

