### PR TITLE
fix: flyway spring boot 3.4.0 test migrations apply in prod

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,12 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-cache'
     implementation 'com.github.ben-manes.caffeine:caffeine'
 
-    implementation 'org.flywaydb:flyway-core'
+    // starting from spring boot 3.4.0 flyway (10.20.1) behavior is ridiculous
+    // it applied migrations from tests on production environment
+    // so I decided to use latest version from maven
+    // 11.1.0, 11.0.1, 10.22.0 works perfect
+    // TODO: use versions from spring dep manager (can it even be trusted after this horrendous upgrade?)
+    implementation 'org.flywaydb:flyway-core:11.1.0'
 //    implementation 'org.jooq:jooq'
 
     // freemarker


### PR DESCRIPTION
# Description

Updated flyway dependency since spring boot 3.4.0 bring broken flyway version that applies test migration on production database.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

It wasn't

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

