### PR TITLE
fix: replaced url encoded whitespace as normal one

### DIFF
--- a/src/main/java/ru/dankoy/korvotoanki/core/service/googletrans/parser/GoogleTranslatorParserImpl.java
+++ b/src/main/java/ru/dankoy/korvotoanki/core/service/googletrans/parser/GoogleTranslatorParserImpl.java
@@ -53,6 +53,9 @@ public class GoogleTranslatorParserImpl implements GoogleTranslatorParser {
               .toList();
     }
 
+    // remove url encoding from translations
+    translationsStrings = translationsStrings.stream().map(t -> t.replaceAll("%20", " ")).toList();
+
     // obtain definitions
     if (Objects.nonNull(definitions)) {
       defs =


### PR DESCRIPTION
# Description

In parser added logic to remove url encoded whitespace as normal one.

Fixes #218

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Export `give way`. It should not contain any `%20` symbols anymore

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

