### PR TITLE
refactor: added help message to commands

### DIFF
--- a/src/main/java/ru/dankoy/korvotoanki/core/command/AnkiConverterCommand.java
+++ b/src/main/java/ru/dankoy/korvotoanki/core/command/AnkiConverterCommand.java
@@ -23,7 +23,33 @@ public class AnkiConverterCommand {
       group = "Anki converter Commands",
       name = "anki-converter",
       alias = "ac",
-      description = "Translate and define text using google translator and dictionaryapi.dev")
+      description = "Translate and define text using google translator and dictionaryapi.dev",
+      help =
+          """
+          SYNOPSIS
+              anki-converter --text String --sourceLanguage String --targetLanguage String --options String[]
+
+          OPTIONS
+             --text String
+             text to define
+             [Required]
+
+              --sourceLanguage String
+             source language
+             [Optional, default = en]
+
+             --targetLanguage String
+             target language
+             [Optional, default = ru]
+
+             --options String[]
+             options
+             [Optional, default = t,at,md,rm]
+
+             --help or -h
+             help for anki-converter
+             [Optional]
+          """)
   public String translateAndConvert(
       @Option(longName = "text", required = true, description = "text to translate") String text,
       @Option(

--- a/src/main/java/ru/dankoy/korvotoanki/core/command/AnkiExporterCommand.java
+++ b/src/main/java/ru/dankoy/korvotoanki/core/command/AnkiExporterCommand.java
@@ -22,7 +22,29 @@ public class AnkiExporterCommand {
       name = "anki-exporter",
       alias = "ae",
       description =
-          "Export to anki. Translate and define text using google translator and dictionaryapi.dev")
+          "Export to anki. Translate and define text using google translator and dictionaryapi.dev",
+      help =
+          """
+          SYNOPSIS
+              anki-exporter --sourceLanguage String --targetLanguage String --options String[]
+
+          OPTIONS
+              --sourceLanguage String
+             source language
+             [Optional, default = en]
+
+             --targetLanguage String
+             target language
+             [Optional, default = ru]
+
+             --options String[]
+             options
+             [Optional, default = t,at,md,rm]
+
+             --help or -h
+             help for anki-exporter
+             [Optional]
+          """)
   public String export(
       @Option(
               longName = "sourceLanguage",

--- a/src/main/java/ru/dankoy/korvotoanki/core/command/DictionaryApiCommand.java
+++ b/src/main/java/ru/dankoy/korvotoanki/core/command/DictionaryApiCommand.java
@@ -19,9 +19,23 @@ public class DictionaryApiCommand {
       group = "Dictionary Api Commands",
       name = "dictionary-api",
       alias = "da",
-      description = "Define word using dictionaryapi.dev")
+      description = "Define word using dictionaryapi.dev",
+      help =
+          """
+          SYNOPSIS
+              dictionary-api --word String
+
+          OPTIONS
+              --word String
+             text to define
+             [Required]
+
+             --help or -h
+             help for dictionary-api
+             [Optional]
+          """)
   public String define(
-      @Option(longName = "word", required = true, description = "text to translate") String word) {
+      @Option(longName = "word", required = true, description = "text to define") String word) {
 
     var translatedString = dictionaryService.define(word);
     return objectMapperService.convertToString(translatedString);

--- a/src/main/java/ru/dankoy/korvotoanki/core/command/GoogleTranslateCommand.java
+++ b/src/main/java/ru/dankoy/korvotoanki/core/command/GoogleTranslateCommand.java
@@ -21,7 +21,29 @@ public class GoogleTranslateCommand {
       group = "Google Translate Commands",
       name = "google-translate",
       alias = "gt",
-      description = "Translate text using google translate")
+      description = "Translate text using google translate",
+      help =
+          """
+          SYNOPSIS
+              google-translate --text String --sourceLanguage String --targetLanguage String --options String[]
+
+          OPTIONS
+              --sourceLanguage String
+             source language
+             [Optional, default = en]
+
+             --targetLanguage String
+             target language
+             [Optional, default = ru]
+
+             --options String[]
+             options
+             [Optional, default = t,at,md,rm]
+
+             --help or -h
+             help for google-translate
+             [Optional]
+          """)
   public String translate(
       @Option(longName = "text", required = true, description = "text to translate") String text,
       @Option(

--- a/src/main/java/ru/dankoy/korvotoanki/core/command/TitleCommand.java
+++ b/src/main/java/ru/dankoy/korvotoanki/core/command/TitleCommand.java
@@ -20,7 +20,17 @@ public class TitleCommand {
       group = "Titles Commands",
       name = "title-count",
       alias = "tc",
-      description = "Count all titles")
+      description = "Count all titles",
+      help =
+          """
+          SYNOPSIS
+              title-count
+
+          OPTIONS
+             --help or -h
+             help for title-get-by-id
+             [Optional]
+          """)
   public String count() {
     Long count = titleService.count();
     return objectMapperService.convertToString(count);
@@ -30,7 +40,21 @@ public class TitleCommand {
       group = "Titles Commands",
       name = "title-get-by-id",
       alias = "tgbi",
-      description = "Get title by id")
+      description = "Get title by id",
+      help =
+          """
+          SYNOPSIS
+              title-get-by-id --id Long
+
+          OPTIONS
+              --id Long
+             title id
+             [Required]
+
+             --help or -h
+             help for title-get-by-id
+             [Optional]
+          """)
   public String getById(
       @Option(longName = "id", required = true, description = "title id") long id) {
     Title title = titleService.getById(id);
@@ -41,7 +65,17 @@ public class TitleCommand {
       group = "Titles Commands",
       name = "title-get-all",
       alias = "tga",
-      description = "Get all titles")
+      description = "Get all titles",
+      help =
+          """
+          SYNOPSIS
+              title-get-all
+
+          OPTIONS
+             --help or -h
+             help for title-get-all
+             [Optional]
+          """)
   public String getAll() {
     List<Title> titles = titleService.getAll();
     return objectMapperService.convertToString(titles);
@@ -51,7 +85,21 @@ public class TitleCommand {
       group = "Titles Commands",
       name = "title-insert",
       alias = "ti",
-      description = "Insert new title")
+      description = "Insert new title",
+      help =
+          """
+          SYNOPSIS
+              title-insert --titleName String
+
+          OPTIONS
+              --titleName String
+             title name
+             [Required]
+
+             --help or -h
+             help for title-insert
+             [Optional]
+          """)
   public String insert(
       @Option(longName = "titleName", required = true, description = "title name")
           String titleName) {
@@ -63,7 +111,21 @@ public class TitleCommand {
       group = "Titles Commands",
       name = "title-delete",
       alias = "td",
-      description = "Delete title by id")
+      description = "Delete title by id",
+      help =
+          """
+          SYNOPSIS
+              title-delete --id Long
+
+          OPTIONS
+              --id Long
+             title id
+             [Required]
+
+             --help or -h
+             help for title-delete
+             [Optional]
+          """)
   public String deleteById(
       @Option(longName = "id", required = true, description = "title id") long id) {
     titleService.deleteById(id);
@@ -74,7 +136,29 @@ public class TitleCommand {
       group = "Titles Commands",
       name = "title-update",
       alias = "tu",
-      description = "Update title")
+      description = "Update title",
+      help =
+          """
+          SYNOPSIS
+              title-update --id Long
+
+          OPTIONS
+              --id Long
+             title name
+             [Required]
+
+             --authorName String
+             author name
+             [Required]
+
+             --filter Long
+             filter (1 or 0)
+             [Required]
+
+             --help or -h
+             help for title-update
+             [Optional]
+          """)
   public String update(
       @Option(longName = "id", required = true, description = "title id") long id,
       @Option(longName = "authorName", required = true, description = "author name")

--- a/src/main/java/ru/dankoy/korvotoanki/core/command/VocabularyCommand.java
+++ b/src/main/java/ru/dankoy/korvotoanki/core/command/VocabularyCommand.java
@@ -22,7 +22,17 @@ public class VocabularyCommand {
       group = "Vocabulary Commands",
       name = "vocabulary-count",
       alias = "vc",
-      description = "Count all vocabulary")
+      description = "Count all vocabulary",
+      help =
+          """
+          SYNOPSIS
+              vocabulary-count
+
+          OPTIONS
+             --help or -h
+             help for vocabulary-count
+             [Optional]
+          """)
   public String count() {
     Long count = vocabularyService.count();
     return objectMapperService.convertToString(count);
@@ -32,7 +42,21 @@ public class VocabularyCommand {
       group = "Vocabulary Commands",
       name = "vocabulary-get-by-title",
       alias = "vgbt",
-      description = "Get vocabulary by title")
+      description = "Get vocabulary by title",
+      help =
+          """
+          SYNOPSIS
+              vocabulary-get-by-title --name String
+
+          OPTIONS
+              --name String
+             title name
+             [Required]
+
+             --help or -h
+             help for vocabulary-get-by-title
+             [Optional]
+          """)
   public String getByTitle(
       @Option(longName = "name", required = true, description = "title name") String titleName) {
 
@@ -45,7 +69,17 @@ public class VocabularyCommand {
       group = "Vocabulary Commands",
       name = "vocabulary-get-all",
       alias = "vga",
-      description = "Get all vocabulary")
+      description = "Get all vocabulary",
+      help =
+          """
+          SYNOPSIS
+              vocabulary-get-all
+
+          OPTIONS
+             --help or -h
+             help for vocabulary-get-by-title
+             [Optional]
+          """)
   public String getAll() {
     List<Vocabulary> vocabulary = vocabularyService.getAll();
     return objectMapperService.convertToString(vocabulary);


### PR DESCRIPTION
# Description

Since Spring Shell 4.0.0 it is necessary to write own help message for each command. Spring doesn't generate it.

Added help messages to all commands.

Kept original style

```text
shell:>ac -h
SYNOPSIS
    anki-converter --text String --sourceLanguage String --targetLanguage String --options String[]

OPTIONS
   --text String
   text to define
   [Required]

    --sourceLanguage String
   source language
   [Optional, default = en]

   --targetLanguage String
   target language
   [Optional, default = ru]

   --options String[]
   options
   [Optional, default = t,at,md,rm]

   --help or -h
   help for anki-converter
   [Optional]

```


Fixes #220

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Check help message for any command. It should be present.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

