### PR TITLE
fix: random npe caused by null list

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ If you want to lemmatize all your words then check another utility - [korvo-to-a
 * Liquibase 
 * Flyway
 * Gradle
+* Resilience4j (Retry, Rate Limit)
 
 ### Integrations
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'ru.dankoy'
-version = '0.4.1-SNAPSHOT'
+version = '0.5.0-SNAPSHOT'
 
 java {
     sourceCompatibility = '21'

--- a/src/main/java/ru/dankoy/korvotoanki/config/RetryResilienceConfig.java
+++ b/src/main/java/ru/dankoy/korvotoanki/config/RetryResilienceConfig.java
@@ -1,0 +1,49 @@
+package ru.dankoy.korvotoanki.config;
+
+import io.github.resilience4j.core.registry.EntryAddedEvent;
+import io.github.resilience4j.core.registry.EntryRemovedEvent;
+import io.github.resilience4j.core.registry.EntryReplacedEvent;
+import io.github.resilience4j.core.registry.RegistryEventConsumer;
+import io.github.resilience4j.retry.Retry;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Slf4j
+@Configuration
+public class RetryResilienceConfig {
+
+  @Bean
+  public RegistryEventConsumer<Retry> myRetryRegistryEventConsumer() {
+
+    return new RegistryEventConsumer<Retry>() {
+      @Override
+      public void onEntryAddedEvent(EntryAddedEvent<Retry> entryAddedEvent) {
+        entryAddedEvent
+            .getAddedEntry()
+            .getEventPublisher()
+            .onEvent(event -> log.info(event.toString()));
+      }
+
+      @Override
+      public void onEntryRemovedEvent(EntryRemovedEvent<Retry> entryRemoveEvent) {
+        entryRemoveEvent
+            .getRemovedEntry()
+            .getEventPublisher()
+            .onEvent(event -> log.info(event.toString()));
+      }
+
+      @Override
+      public void onEntryReplacedEvent(EntryReplacedEvent<Retry> entryReplacedEvent) {
+        entryReplacedEvent
+            .getOldEntry()
+            .getEventPublisher()
+            .onEvent(event -> log.info(event.toString()));
+        entryReplacedEvent
+            .getNewEntry()
+            .getEventPublisher()
+            .onEvent(event -> log.info(event.toString()));
+      }
+    };
+  }
+}

--- a/src/main/java/ru/dankoy/korvotoanki/config/WebClientConfig.java
+++ b/src/main/java/ru/dankoy/korvotoanki/config/WebClientConfig.java
@@ -17,7 +17,7 @@ import reactor.netty.http.client.HttpClient;
 @Configuration
 public class WebClientConfig {
 
-  public static final int TIMEOUT = 30000;
+  public static final int TIMEOUT = 15000;
 
   @Bean
   public WebClient webClientWithTimeout() {

--- a/src/main/java/ru/dankoy/korvotoanki/config/WebClientConfig.java
+++ b/src/main/java/ru/dankoy/korvotoanki/config/WebClientConfig.java
@@ -3,6 +3,7 @@ package ru.dankoy.korvotoanki.config;
 import io.netty.channel.ChannelOption;
 import io.netty.handler.timeout.ReadTimeoutHandler;
 import io.netty.handler.timeout.WriteTimeoutHandler;
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
@@ -16,7 +17,7 @@ import reactor.netty.http.client.HttpClient;
 @Configuration
 public class WebClientConfig {
 
-  public static final int TIMEOUT = 10000;
+  public static final int TIMEOUT = 30000;
 
   @Bean
   public WebClient webClientWithTimeout() {
@@ -24,6 +25,7 @@ public class WebClientConfig {
     final var httpClient =
         HttpClient.create()
             .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, TIMEOUT)
+            .responseTimeout(Duration.ofMillis(TIMEOUT))
             .doOnConnected(
                 connection -> {
                   connection.addHandlerLast(new ReadTimeoutHandler(TIMEOUT, TimeUnit.MILLISECONDS));
@@ -35,7 +37,10 @@ public class WebClientConfig {
         .clientConnector(new ReactorClientHttpConnector(httpClient))
         .defaultHeaders(
             httpHeaders -> {
-              httpHeaders.set(HttpHeaders.USER_AGENT, "Mozilla/5.0 (Windows NT 10.0; Win64; x64)");
+              httpHeaders.set(
+                  HttpHeaders.USER_AGENT,
+                  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko)"
+                      + " Chrome/147.0.0.0 Safari/537.36");
             })
         .build();
   }

--- a/src/main/java/ru/dankoy/korvotoanki/config/WebClientConfig.java
+++ b/src/main/java/ru/dankoy/korvotoanki/config/WebClientConfig.java
@@ -17,7 +17,7 @@ import reactor.netty.http.client.HttpClient;
 @Configuration
 public class WebClientConfig {
 
-  public static final int TIMEOUT = 15000;
+  public static final int TIMEOUT = 10000;
 
   @Bean
   public WebClient webClientWithTimeout() {

--- a/src/main/java/ru/dankoy/korvotoanki/core/service/converter/AnkiConverterServiceCompletableFuture.java
+++ b/src/main/java/ru/dankoy/korvotoanki/core/service/converter/AnkiConverterServiceCompletableFuture.java
@@ -58,6 +58,11 @@ public class AnkiConverterServiceCompletableFuture implements AnkiConverterServi
                 ankiConverterTaskExecutor)
             .handle(
                 (result, ex) -> {
+                  log.atDebug()
+                      .setMessage("Handle exception for word {}: {}")
+                      .addArgument(vocabulary.word())
+                      .addArgument(ex)
+                      .log();
                   if (ex != null
                       && (ex.getCause() instanceof DictionaryApiException
                           || ex.getCause() instanceof WebClientResponseException

--- a/src/main/java/ru/dankoy/korvotoanki/core/service/converter/AnkiConverterServiceCompletableFuture.java
+++ b/src/main/java/ru/dankoy/korvotoanki/core/service/converter/AnkiConverterServiceCompletableFuture.java
@@ -8,6 +8,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClientRequestException;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
 import ru.dankoy.korvotoanki.config.Languages;
 import ru.dankoy.korvotoanki.config.appprops.ExternalApiProperties;
 import ru.dankoy.korvotoanki.core.domain.Vocabulary;
@@ -56,11 +58,15 @@ public class AnkiConverterServiceCompletableFuture implements AnkiConverterServi
                 ankiConverterTaskExecutor)
             .handle(
                 (result, ex) -> {
-                  if (ex != null && ex.getCause() instanceof DictionaryApiException) {
+                  if (ex != null
+                      && (ex.getCause() instanceof DictionaryApiException
+                          || ex.getCause() instanceof WebClientResponseException
+                          || ex.getCause() instanceof WebClientRequestException)) {
                     log.warn(
                         String.format(
-                            "Couldn't get definition from dictionaryapi.dev for '%s' - %s",
-                            vocabulary.word(), ex.getMessage()));
+                            "Couldn't get definition from dictionaryapi.dev for '%s' with cause"
+                                + " '%s'. Fallback to empty word.",
+                            vocabulary.word(), ex.getCause().getMessage()));
                     return Collections.singletonList(Word.emptyWord());
                   }
                   return result;

--- a/src/main/java/ru/dankoy/korvotoanki/core/service/dictionaryapi/DictionaryServiceWebClient.java
+++ b/src/main/java/ru/dankoy/korvotoanki/core/service/dictionaryapi/DictionaryServiceWebClient.java
@@ -1,6 +1,7 @@
 package ru.dankoy.korvotoanki.core.service.dictionaryapi;
 
 import io.github.resilience4j.ratelimiter.annotation.RateLimiter;
+import io.github.resilience4j.retry.annotation.Retry;
 import java.util.List;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
@@ -28,6 +29,7 @@ public class DictionaryServiceWebClient implements DictionaryService {
 
   private final DictionaryApiProperties dictionaryApiProperties;
 
+  @Retry(name = "dictionary-api")
   @RateLimiter(name = "dictionary-api")
   @Cacheable(cacheManager = "cacheManager", value = "dictionaryApi", key = "#word")
   @Override
@@ -60,4 +62,11 @@ public class DictionaryServiceWebClient implements DictionaryService {
         .bodyToMono(String.class)
         .flatMap(body -> Mono.error(new DictionaryApiException(body)));
   }
+
+  // public List<Word> fallback(String word, Exception ex) {
+  //   // this method is always called by resilience4j even if it ignores exception in
+  // configuration.
+  //   log.warn(String.format("Fallback to empty word after retry exhaust for - %s", word));
+  //   return List.of(Word.emptyWord());
+  // }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -32,6 +32,8 @@ logging:
   pattern:
     console: "%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"
     file: "%d %p %c{1.} [%t] %m%n"
+  file:
+    name: full-shell.log
 
 korvo-to-anki:
   files:
@@ -75,3 +77,16 @@ resilience4j.ratelimiter:
       limitForPeriod: 5
       limitRefreshPeriod: 5s
       timeoutDuration: 6s
+resilience4j.retry:
+    configs:
+      default:
+        max-attempts: 3
+        wait-duration: 1000
+        retry-exceptions:
+          - org.springframework.web.reactive.function.client.WebClientResponseException
+          - org.springframework.web.reactive.function.client.WebClientRequestException
+    instances:
+      dictionary-api:
+        base-config: default
+        ignore-exceptions:
+          - ru.dankoy.korvotoanki.core.exceptions.DictionaryApiException

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,12 +28,14 @@ spring:
 
 logging:
   level:
+    root: INFO
     ru.dankoy.*: INFO
   pattern:
     console: "%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"
     file: "%d %p %c{1} [%t] %m%n"
   file:
     name: full-shell.log
+  
   logback:
     rollingpolicy:
       max-file-size: 10MB
@@ -89,6 +91,8 @@ resilience4j.retry:
         retry-exceptions:
           - org.springframework.web.reactive.function.client.WebClientResponseException
           - org.springframework.web.reactive.function.client.WebClientRequestException
+          - io.netty.handler.timeout.ReadTimeoutException
+          - io.netty.handler.timeout.WriteTimeoutException
     instances:
       dictionary-api:
         base-config: default

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -31,9 +31,13 @@ logging:
     ru.dankoy.*: INFO
   pattern:
     console: "%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"
-    file: "%d %p %c{1.} [%t] %m%n"
+    file: "%d %p %c{1} [%t] %m%n"
   file:
     name: full-shell.log
+  logback:
+    rollingpolicy:
+      max-file-size: 10MB
+      max-history: 7
 
 korvo-to-anki:
   files:

--- a/src/test/java/ru/dankoy/korvotoanki/core/service/converter/AnkiConverterServiceCompletableFutureTest.java
+++ b/src/test/java/ru/dankoy/korvotoanki/core/service/converter/AnkiConverterServiceCompletableFutureTest.java
@@ -14,6 +14,8 @@ import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.web.reactive.function.client.WebClientRequestException;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
 import ru.dankoy.korvotoanki.config.ThreadPoolConfig;
 import ru.dankoy.korvotoanki.config.appprops.ExternalApiParams;
 import ru.dankoy.korvotoanki.config.appprops.ExternalApiProperties;
@@ -25,10 +27,11 @@ import ru.dankoy.korvotoanki.core.domain.dictionaryapi.Phonetics;
 import ru.dankoy.korvotoanki.core.domain.dictionaryapi.Word;
 import ru.dankoy.korvotoanki.core.domain.googletranslation.Definition;
 import ru.dankoy.korvotoanki.core.domain.googletranslation.GoogleTranslation;
+import ru.dankoy.korvotoanki.core.exceptions.DictionaryApiException;
 import ru.dankoy.korvotoanki.core.fabric.anki.AnkiDataFabric;
 import ru.dankoy.korvotoanki.core.fabric.anki.AnkiDataFabricImpl;
-import ru.dankoy.korvotoanki.core.service.dictionaryapi.DictionaryService;
 import ru.dankoy.korvotoanki.core.service.dictionaryapi.DictionaryServiceOkHttp;
+import ru.dankoy.korvotoanki.core.service.dictionaryapi.DictionaryServiceWebClient;
 import ru.dankoy.korvotoanki.core.service.googletrans.GoogleTranslator;
 import ru.dankoy.korvotoanki.core.service.googletrans.GoogleTranslatorOkHttp;
 
@@ -45,7 +48,7 @@ import ru.dankoy.korvotoanki.core.service.googletrans.GoogleTranslatorOkHttp;
     properties = {"korvo-to-anki.async=true", "korvo-to-anki.async-type=vtcf"})
 class AnkiConverterServiceCompletableFutureTest {
 
-  @MockitoBean private DictionaryService dictionaryService;
+  @MockitoBean private DictionaryServiceWebClient dictionaryService;
 
   @MockitoBean private GoogleTranslator googleTranslator;
 
@@ -162,6 +165,102 @@ class AnkiConverterServiceCompletableFutureTest {
         .willReturn(gtResult);
     given(ankiDataFabric.createAnkiData(vocabulary, gtResult, daResult)).willReturn(ankiData);
     given(dictionaryService.define(vocabulary.word())).willReturn(daResult);
+
+    var actual = ankiConverterService.convert(vocabulary, sourceLanguage, targetLanguage, options);
+
+    assertThat(actual).isEqualTo(ankiData);
+
+    Mockito.verify(ankiDataFabric, times(1)).createAnkiData(vocabulary, gtResult, daResult);
+    Mockito.verify(googleTranslator, times(1))
+        .translate(vocabulary.word(), targetLanguage, sourceLanguage, options);
+    Mockito.verify(dictionaryService, times(1)).define(vocabulary.word());
+    Mockito.verify(externalApiProperties, times(1)).isDictionaryApiEnabled();
+  }
+
+  @DisplayName(
+      "convert with english source, dictionary api enabled, expects WebClientRequestException from"
+          + " dictionaryapi service")
+  @Test
+  void convertEnglishSourceAndDictionaryApiEnabledExpectsWebClientRequestException() {
+
+    var sourceLanguage = "en";
+    var targetLanguage = "whatever";
+    List<String> options = Stream.of("t", "md", "at", "rm").toList();
+
+    List<Word> daResult = getWords(true);
+    var vocabulary = getOneVocab();
+    var gtResult = getOneGt();
+    var ankiData = getOneFromGoogleTranslate(vocabulary, gtResult);
+
+    given(externalApiProperties.isDictionaryApiEnabled()).willReturn(true);
+    given(googleTranslator.translate(vocabulary.word(), targetLanguage, sourceLanguage, options))
+        .willReturn(gtResult);
+    given(ankiDataFabric.createAnkiData(vocabulary, gtResult, daResult)).willReturn(ankiData);
+    given(dictionaryService.define(vocabulary.word())).willThrow(WebClientRequestException.class);
+
+    var actual = ankiConverterService.convert(vocabulary, sourceLanguage, targetLanguage, options);
+
+    assertThat(actual).isEqualTo(ankiData);
+
+    Mockito.verify(ankiDataFabric, times(1)).createAnkiData(vocabulary, gtResult, daResult);
+    Mockito.verify(googleTranslator, times(1))
+        .translate(vocabulary.word(), targetLanguage, sourceLanguage, options);
+    Mockito.verify(dictionaryService, times(1)).define(vocabulary.word());
+    Mockito.verify(externalApiProperties, times(1)).isDictionaryApiEnabled();
+  }
+
+  @DisplayName(
+      "convert with english source, dictionary api enabled, expects WebClientResponseException from"
+          + " dictionaryapi service")
+  @Test
+  void convertEnglishSourceAndDictionaryApiEnabledExpectsWebClientResponseException() {
+
+    var sourceLanguage = "en";
+    var targetLanguage = "whatever";
+    List<String> options = Stream.of("t", "md", "at", "rm").toList();
+
+    List<Word> daResult = getWords(true);
+    var vocabulary = getOneVocab();
+    var gtResult = getOneGt();
+    var ankiData = getOneFromGoogleTranslate(vocabulary, gtResult);
+
+    given(externalApiProperties.isDictionaryApiEnabled()).willReturn(true);
+    given(googleTranslator.translate(vocabulary.word(), targetLanguage, sourceLanguage, options))
+        .willReturn(gtResult);
+    given(ankiDataFabric.createAnkiData(vocabulary, gtResult, daResult)).willReturn(ankiData);
+    given(dictionaryService.define(vocabulary.word()))
+        .willThrow(WebClientResponseException.create(200, "status", null, null, null));
+
+    var actual = ankiConverterService.convert(vocabulary, sourceLanguage, targetLanguage, options);
+
+    assertThat(actual).isEqualTo(ankiData);
+
+    Mockito.verify(ankiDataFabric, times(1)).createAnkiData(vocabulary, gtResult, daResult);
+    Mockito.verify(googleTranslator, times(1))
+        .translate(vocabulary.word(), targetLanguage, sourceLanguage, options);
+    Mockito.verify(dictionaryService, times(1)).define(vocabulary.word());
+    Mockito.verify(externalApiProperties, times(1)).isDictionaryApiEnabled();
+  }
+
+  @DisplayName(
+      "convert with english source, dictionary api enabled, expects DictionaryApiException")
+  @Test
+  void convertEnglishSourceAndDictionaryApiEnabledExpectsDictionaryApiException() {
+
+    var sourceLanguage = "en";
+    var targetLanguage = "whatever";
+    List<String> options = Stream.of("t", "md", "at", "rm").toList();
+
+    List<Word> daResult = getWords(true);
+    var vocabulary = getOneVocab();
+    var gtResult = getOneGt();
+    var ankiData = getOneFromGoogleTranslate(vocabulary, gtResult);
+
+    given(externalApiProperties.isDictionaryApiEnabled()).willReturn(true);
+    given(googleTranslator.translate(vocabulary.word(), targetLanguage, sourceLanguage, options))
+        .willReturn(gtResult);
+    given(ankiDataFabric.createAnkiData(vocabulary, gtResult, daResult)).willReturn(ankiData);
+    given(dictionaryService.define(vocabulary.word())).willThrow(DictionaryApiException.class);
 
     var actual = ankiConverterService.convert(vocabulary, sourceLanguage, targetLanguage, options);
 

--- a/src/test/java/ru/dankoy/korvotoanki/core/service/dictionaryapi/DictionaryServiceOkHttpTest.java
+++ b/src/test/java/ru/dankoy/korvotoanki/core/service/dictionaryapi/DictionaryServiceOkHttpTest.java
@@ -23,8 +23,6 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import ru.dankoy.korvotoanki.config.appprops.AppProperties;

--- a/src/test/java/ru/dankoy/korvotoanki/core/service/dictionaryapi/DictionaryServiceOkHttpTest.java
+++ b/src/test/java/ru/dankoy/korvotoanki/core/service/dictionaryapi/DictionaryServiceOkHttpTest.java
@@ -23,6 +23,8 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import ru.dankoy.korvotoanki.config.appprops.AppProperties;
@@ -41,6 +43,7 @@ import ru.dankoy.korvotoanki.core.exceptions.DictionaryApiException;
     })
 @ExtendWith(MockitoExtension.class) // necessary for @Mock annotation to work
 @TestPropertySource(properties = "korvo-to-anki.http-client=ok-http")
+@DirtiesContext(classMode = ClassMode.AFTER_CLASS)
 class DictionaryServiceOkHttpTest {
 
   @MockitoBean private OkHttpClient okHttpClient;

--- a/src/test/java/ru/dankoy/korvotoanki/core/service/dictionaryapi/DictionaryServiceOkHttpTest.java
+++ b/src/test/java/ru/dankoy/korvotoanki/core/service/dictionaryapi/DictionaryServiceOkHttpTest.java
@@ -43,7 +43,6 @@ import ru.dankoy.korvotoanki.core.exceptions.DictionaryApiException;
     })
 @ExtendWith(MockitoExtension.class) // necessary for @Mock annotation to work
 @TestPropertySource(properties = "korvo-to-anki.http-client=ok-http")
-@DirtiesContext(classMode = ClassMode.AFTER_CLASS)
 class DictionaryServiceOkHttpTest {
 
   @MockitoBean private OkHttpClient okHttpClient;

--- a/src/test/java/ru/dankoy/korvotoanki/core/service/dictionaryapi/DictionaryServiceWebClientTest.java
+++ b/src/test/java/ru/dankoy/korvotoanki/core/service/dictionaryapi/DictionaryServiceWebClientTest.java
@@ -48,7 +48,6 @@ import ru.dankoy.korvotoanki.core.exceptions.DictionaryApiException;
       ObjectMapper.class,
       DictionaryServiceWebClient.class
     })
-// @DirtiesContext(classMode = ClassMode.AFTER_CLASS)
 // @TestPropertySource(properties = "korvo-to-anki.http-client=web-client")
 class DictionaryServiceWebClientTest {
 

--- a/src/test/java/ru/dankoy/korvotoanki/core/service/dictionaryapi/DictionaryServiceWebClientTest.java
+++ b/src/test/java/ru/dankoy/korvotoanki/core/service/dictionaryapi/DictionaryServiceWebClientTest.java
@@ -18,8 +18,7 @@ import java.util.stream.Stream;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.SocketPolicy;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -49,20 +48,22 @@ import ru.dankoy.korvotoanki.core.exceptions.DictionaryApiException;
       ObjectMapper.class,
       DictionaryServiceWebClient.class
     })
+// @DirtiesContext(classMode = ClassMode.AFTER_CLASS)
 // @TestPropertySource(properties = "korvo-to-anki.http-client=web-client")
 class DictionaryServiceWebClientTest {
 
-  private static MockWebServer server;
+  private MockWebServer server;
   private String mockUrl = "http://127.0.0.1:%s/";
 
-  @BeforeAll
-  static void setUp() throws IOException {
+  @BeforeEach
+  void setUp() throws IOException {
     server = new MockWebServer();
     server.start();
+    mockUrl = String.format(mockUrl, server.getPort());
   }
 
-  @AfterAll
-  static void tearDown() throws IOException {
+  @AfterEach
+  void tearDown() throws IOException {
     server.shutdown();
   }
 
@@ -71,11 +72,6 @@ class DictionaryServiceWebClientTest {
   @Autowired private DictionaryServiceWebClient dictionaryService;
 
   @Autowired private ObjectMapper mapper;
-
-  @BeforeEach
-  void initialize() {
-    mockUrl = String.format(mockUrl, server.getPort());
-  }
 
   @DisplayName("correct translation")
   @Test

--- a/src/test/java/ru/dankoy/korvotoanki/core/service/dictionaryapi/DictionaryServiceWebClientTestResilience.java
+++ b/src/test/java/ru/dankoy/korvotoanki/core/service/dictionaryapi/DictionaryServiceWebClientTestResilience.java
@@ -46,8 +46,6 @@ import tools.jackson.databind.ObjectMapper;
       org.springframework.boot.liquibase.autoconfigure.LiquibaseAutoConfiguration.class,
       org.springframework.boot.flyway.autoconfigure.FlywayAutoConfiguration.class
     })
-// @DirtiesContext(classMode = ClassMode.AFTER_CLASS)
-
 public class DictionaryServiceWebClientTestResilience {
 
   @TestConfiguration

--- a/src/test/java/ru/dankoy/korvotoanki/core/service/dictionaryapi/DictionaryServiceWebClientTestResilience.java
+++ b/src/test/java/ru/dankoy/korvotoanki/core/service/dictionaryapi/DictionaryServiceWebClientTestResilience.java
@@ -1,0 +1,159 @@
+package ru.dankoy.korvotoanki.core.service.dictionaryapi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+
+import io.netty.channel.ChannelOption;
+import io.netty.handler.timeout.ReadTimeoutHandler;
+import io.netty.handler.timeout.WriteTimeoutHandler;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.SocketPolicy;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientRequestException;
+import reactor.netty.http.client.HttpClient;
+import ru.dankoy.korvotoanki.KorvoToAnkiApplication;
+import ru.dankoy.korvotoanki.config.appprops.DictionaryApiProperties;
+import ru.dankoy.korvotoanki.config.appprops.GoogleTranslatorProperties;
+import ru.dankoy.korvotoanki.core.exceptions.DictionaryApiException;
+import tools.jackson.databind.ObjectMapper;
+
+@DisplayName("Test DictionaryServiceWebClient with full contexst and resilience ")
+@Import(DictionaryServiceWebClientTestResilience.WebClientConfigInternal.class)
+@SpringBootTest(classes = {KorvoToAnkiApplication.class})
+@EnableAutoConfiguration(
+    exclude = {
+      org.springframework.boot.liquibase.autoconfigure.LiquibaseAutoConfiguration.class,
+      org.springframework.boot.flyway.autoconfigure.FlywayAutoConfiguration.class
+    })
+// @DirtiesContext(classMode = ClassMode.AFTER_CLASS)
+
+public class DictionaryServiceWebClientTestResilience {
+
+  @TestConfiguration
+  static class WebClientConfigInternal {
+
+    @Primary
+    @Bean
+    public WebClient webClientWithTimeoutTest() {
+
+      final var httpClient =
+          HttpClient.create()
+              .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 1000)
+              .doOnConnected(
+                  connection -> {
+                    connection.addHandlerLast(new ReadTimeoutHandler(1000, TimeUnit.MILLISECONDS));
+                    connection.addHandlerLast(new WriteTimeoutHandler(1000, TimeUnit.MILLISECONDS));
+                  });
+
+      return WebClient.builder()
+          .clientConnector(new ReactorClientHttpConnector(httpClient))
+          .defaultHeaders(
+              httpHeaders -> {
+                httpHeaders.set(
+                    HttpHeaders.USER_AGENT, "Mozilla/5.0 (Windows NT 10.0; Win64; x64)");
+              })
+          .build();
+    }
+  }
+
+  private MockWebServer server;
+  private String mockUrl = "http://127.0.0.1:%s/";
+
+  @BeforeEach
+  void setUp() throws IOException {
+    server = new MockWebServer();
+    server.start();
+    mockUrl = String.format(mockUrl, server.getPort());
+  }
+
+  @AfterEach
+  void tearDown() throws IOException {
+    server.shutdown();
+  }
+
+  @MockitoBean private DictionaryApiProperties dictionaryApiProperties;
+
+  @MockitoBean private GoogleTranslatorProperties googleTranslatorProperties;
+
+  @Autowired private DictionaryServiceWebClient dictionaryService;
+
+  @MockitoSpyBean private WebClient webClientWithTimeoutTest;
+
+  @Autowired private ObjectMapper mapper;
+
+  @DisplayName("definition read timeout expects retry and the throw WebClientRequestException")
+  @Test
+  void defineReadTimeout_expectRetries() throws InterruptedException {
+
+    given(dictionaryApiProperties.getDictionaryApiUrl()).willReturn(mockUrl);
+    var word = "exception_word";
+
+    server.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.NO_RESPONSE));
+
+    assertThatThrownBy(() -> dictionaryService.define(word))
+        .isInstanceOf(WebClientRequestException.class);
+
+    var req = server.takeRequest();
+    assertThat(req.getMethod()).isEqualTo("GET");
+    assertThat(req.getPath().substring(1)).isEqualTo(word);
+
+    Mockito.verify(webClientWithTimeoutTest, times(3)).get();
+    Mockito.verify(dictionaryApiProperties, times(3)).getDictionaryApiUrl();
+  }
+
+  @DisplayName("definition read timeout expect no retries and throw DictionaryApiException")
+  @Test
+  void defineReadTimeout_expectNoRetries() throws InterruptedException {
+
+    given(dictionaryApiProperties.getDictionaryApiUrl()).willReturn(mockUrl);
+    var word = "exception_word";
+
+    server.enqueue(
+        new MockResponse()
+            .setBody(mapper.writeValueAsString(getBody(false)))
+            .setResponseCode(404)
+            .addHeader("Content-Type", "application/json"));
+
+    assertThatThrownBy(() -> dictionaryService.define(word))
+        .isInstanceOf(DictionaryApiException.class);
+
+    var req = server.takeRequest();
+    assertThat(req.getMethod()).isEqualTo("GET");
+    assertThat(req.getPath().substring(1)).isEqualTo(word);
+
+    Mockito.verify(webClientWithTimeoutTest, times(1)).get();
+    Mockito.verify(dictionaryApiProperties, times(1)).getDictionaryApiUrl();
+  }
+
+  private String getBody(boolean isCorrect) {
+
+    if (isCorrect) {
+      return "[{\"word\":\"data\",\"phonetic\":\"phonetic\",\"phonetics\":[{\"text\":\"text\",\"audio\":\"audio\",\"sourceUrl\":\"source\"}],\"meanings\":[{\"partOfSpeech\":\"ps\",\"definitions\":[{\"definition\":\"info\",\"synonyms\":[\"synonym1\"],\"antonyms\":[\"antonym1\"],\"example\":\"example\"}],\"synonyms\":[\"synonym1\"],\"antonyms\":[\"antonym1\"]}]}]";
+    } else {
+      return "{\"title\":\"No Definitions Found\",\"message\":\"Sorry pal, we couldn't find"
+          + " definitions for the word you were looking for.\",\"resolution\":\"You can try"
+          + " the search again at later time or head to the web instead.\"}";
+    }
+  }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -27,6 +27,7 @@ spring:
 
 logging:
   level:
+    root: INFO
     ru.dankoy.*: INFO
   pattern:
     console: "%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"
@@ -81,6 +82,8 @@ resilience4j.retry:
         retry-exceptions:
           - org.springframework.web.reactive.function.client.WebClientResponseException
           - org.springframework.web.reactive.function.client.WebClientRequestException
+          - io.netty.handler.timeout.ReadTimeoutException
+          - io.netty.handler.timeout.WriteTimeoutException
     instances:
       dictionary-api:
         base-config: default

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -31,6 +31,8 @@ logging:
   pattern:
     console: "%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"
     file: "%d %p %c{1.} [%t] %m%n"
+  file:
+    name: full-shell.log
 
 korvo-to-anki:
   files:
@@ -66,3 +68,18 @@ korvo-to-anki:
 #      - "rw"        # "see also" list
 #      - "ss"        # synonyms of source text, if it's one word
 debug: false
+
+resilience4j.retry:
+    configs:
+      default:
+        max-attempts: 3
+        wait-duration: 1000
+        retry-exceptions:
+          - org.springframework.web.reactive.function.client.WebClientResponseException
+          - org.springframework.web.reactive.function.client.WebClientRequestException
+    instances:
+      dictionary-api:
+        base-config: default
+        ignore-exceptions:
+          - ru.dankoy.korvotoanki.core.exceptions.DictionaryApiException
+        

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -30,9 +30,13 @@ logging:
     ru.dankoy.*: INFO
   pattern:
     console: "%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"
-    file: "%d %p %c{1.} [%t] %m%n"
+    file: "%d %p %c{1} [%t] %m%n"
   file:
-    name: full-shell.log
+    name: full-shell-test.log
+  logback:
+    rollingpolicy:
+      max-file-size: 10MB
+      max-history: 7
 
 korvo-to-anki:
   files:


### PR DESCRIPTION
# Description

1) Added retry using resilience4j for dictionary-api service. It retries only 
    - org.springframework.web.reactive.function.client.WebClientResponseException
    - org.springframework.web.reactive.function.client.WebClientRequestException
2) Fixed logic in AnkiConverterServiceCompletableFuture to correctly catch exceptions above (if retry exhausts) then use empty word.
3) Added logging into separate file for full-log.shell
4) Added tests, including retry logic tests.
5) Added logging for retry events.
6) Updated release to 0.5.0

> [!WARNING]
> In some cases there are same npe, but i couldn't find it after full export of 4500 words.
> Debugged export for two days, couldn't get what is randomly causing it. 
> But most of exceptional events which leads to this NPE has been fixed with this PR

Fixes #216

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Full export for 4500 words. Everything should be fine.


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

